### PR TITLE
Keyboard layouts for Bashkir language

### DIFF
--- a/data/bak/stdbug/keyboard/bak_key_default.json
+++ b/data/bak/stdbug/keyboard/bak_key_default.json
@@ -1,0 +1,218 @@
+{
+  "version": "1.0",
+  "layout_name": "Bashkir (4-rows)",
+  "vendor": "https://github.com/stdbug",
+  "rows": 4,
+  "keys": [
+    {
+      "label": "Ә",
+      "row": 0,
+      "column": 0
+    },
+    {
+      "label": "Ө",
+      "row": 0,
+      "column": 1
+    },
+    {
+      "label": "Ҡ",
+      "row": 0,
+      "column": 2
+    },
+    {
+      "label": "Ғ",
+      "row": 0,
+      "column": 3
+    },
+    {
+      "label": "Ҫ",
+      "row": 0,
+      "column": 4
+    },
+    {
+      "label": "Ҙ",
+      "row": 0,
+      "column": 5
+    },
+    {
+      "label": "Һ",
+      "row": 0,
+      "column": 6
+    },
+    {
+      "label": "Ү",
+      "row": 0,
+      "column": 7
+    },
+    {
+      "label": "Ң",
+      "row": 0,
+      "column": 8
+    },
+    {
+      "label": "Ё",
+      "row": 0,
+      "column": 9
+    },
+    {
+      "label": "Ъ",
+      "row": 0,
+      "column": 10
+    },
+    {
+      "label": "Й",
+      "row": 1,
+      "column": 0
+    },
+    {
+      "label": "Ц",
+      "row": 1,
+      "column": 1
+    },
+    {
+      "label": "У",
+      "row": 1,
+      "column": 2
+    },
+    {
+      "label": "К",
+      "row": 1,
+      "column": 3
+    },
+    {
+      "label": "Е",
+      "row": 1,
+      "column": 4
+    },
+    {
+      "label": "Н",
+      "row": 1,
+      "column": 5
+    },
+    {
+      "label": "Г",
+      "row": 1,
+      "column": 6
+    },
+    {
+      "label": "Ш",
+      "row": 1,
+      "column": 7
+    },
+    {
+      "label": "Щ",
+      "row": 1,
+      "column": 8
+    },
+    {
+      "label": "З",
+      "row": 1,
+      "column": 9
+    },
+    {
+      "label": "Х",
+      "row": 1,
+      "column": 10
+    },
+    {
+      "label": "Ф",
+      "row": 2,
+      "column": 0
+    },
+    {
+      "label": "Ы",
+      "row": 2,
+      "column": 1
+    },
+    {
+      "label": "В",
+      "row": 2,
+      "column": 2
+    },
+    {
+      "label": "А",
+      "row": 2,
+      "column": 3
+    },
+    {
+      "label": "П",
+      "row": 2,
+      "column": 4
+    },
+    {
+      "label": "Р",
+      "row": 2,
+      "column": 5
+    },
+    {
+      "label": "О",
+      "row": 2,
+      "column": 6
+    },
+    {
+      "label": "Л",
+      "row": 2,
+      "column": 7
+    },
+    {
+      "label": "Д",
+      "row": 2,
+      "column": 8
+    },
+    {
+      "label": "Ж",
+      "row": 2,
+      "column": 9
+    },
+    {
+      "label": "Э",
+      "row": 2,
+      "column": 10
+    },
+    {
+      "label": "Я",
+      "row": 3,
+      "column": 0
+    },
+    {
+      "label": "Ч",
+      "row": 3,
+      "column": 1
+    },
+    {
+      "label": "С",
+      "row": 3,
+      "column": 2
+    },
+    {
+      "label": "М",
+      "row": 3,
+      "column": 3
+    },
+    {
+      "label": "И",
+      "row": 3,
+      "column": 4
+    },
+    {
+      "label": "Т",
+      "row": 3,
+      "column": 5
+    },
+    {
+      "label": "Ь",
+      "row": 3,
+      "column": 6
+    },
+    {
+      "label": "Б",
+      "row": 3,
+      "column": 7
+    },
+    {
+      "label": "Ю",
+      "row": 3,
+      "column": 8
+    }
+  ]
+}

--- a/data/bak/stdbug/keyboard/bak_long_press.json
+++ b/data/bak/stdbug/keyboard/bak_long_press.json
@@ -1,0 +1,231 @@
+{
+  "version": "1.0",
+  "layout_name": "Bashkir (customized)",
+  "vendor": "https://github.com/stdbug",
+  "rows": 4,
+  "keys": [
+    {
+      "label": "Й",
+      "row": 1,
+      "column": 0
+    },
+    {
+      "label": "Ц",
+      "row": 1,
+      "column": 1
+    },
+    {
+      "label": "У",
+      "row": 1,
+      "column": 2
+    },
+    {
+      "label": "К",
+      "row": 1,
+      "column": 3
+    },
+    {
+      "label": "Е",
+      "row": 1,
+      "column": 4
+    },
+    {
+      "label": "Н",
+      "row": 1,
+      "column": 5
+    },
+    {
+      "label": "Г",
+      "row": 1,
+      "column": 6
+    },
+    {
+      "label": "Ш",
+      "row": 1,
+      "column": 7
+    },
+    {
+      "label": "Щ",
+      "row": 1,
+      "column": 8
+    },
+    {
+      "label": "З",
+      "row": 1,
+      "column": 9
+    },
+    {
+      "label": "Х",
+      "row": 1,
+      "column": 10
+    },
+    {
+      "label": "Ф",
+      "row": 2,
+      "column": 0
+    },
+    {
+      "label": "Ы",
+      "row": 2,
+      "column": 1
+    },
+    {
+      "label": "В",
+      "row": 2,
+      "column": 2
+    },
+    {
+      "label": "А",
+      "row": 2,
+      "column": 3
+    },
+    {
+      "label": "П",
+      "row": 2,
+      "column": 4
+    },
+    {
+      "label": "Р",
+      "row": 2,
+      "column": 5
+    },
+    {
+      "label": "О",
+      "row": 2,
+      "column": 6
+    },
+    {
+      "label": "Л",
+      "row": 2,
+      "column": 7
+    },
+    {
+      "label": "Д",
+      "row": 2,
+      "column": 8
+    },
+    {
+      "label": "Ж",
+      "row": 2,
+      "column": 9
+    },
+    {
+      "label": "Э",
+      "row": 2,
+      "column": 10
+    },
+    {
+      "label": "Я",
+      "row": 3,
+      "column": 0
+    },
+    {
+      "label": "Ч",
+      "row": 3,
+      "column": 1
+    },
+    {
+      "label": "С",
+      "row": 3,
+      "column": 2
+    },
+    {
+      "label": "М",
+      "row": 3,
+      "column": 3
+    },
+    {
+      "label": "И",
+      "row": 3,
+      "column": 4
+    },
+    {
+      "label": "Т",
+      "row": 3,
+      "column": 5
+    },
+    {
+      "label": "Ь",
+      "row": 3,
+      "column": 6
+    },
+    {
+      "label": "Б",
+      "row": 3,
+      "column": 7
+    },
+    {
+      "label": "Ю",
+      "row": 3,
+      "column": 8
+    }
+  ],
+  "long_press": [
+    {
+      "key": "У",
+      "alternates": [
+        "Ү"
+      ]
+    },
+    {
+      "key": "К",
+      "alternates": [
+        "Ҡ"
+      ]
+    },
+    {
+      "key": "Е",
+      "alternates": [
+        "Ё"
+      ]
+    },
+    {
+      "key": "Н",
+      "alternates": [
+        "Ң"
+      ]
+    },
+    {
+      "key": "Г",
+      "alternates": [
+        "Ғ"
+      ]
+    },
+    {
+      "key": "З",
+      "alternates": [
+        "Ҙ"
+      ]
+    },
+    {
+      "key": "Х",
+      "alternates": [
+        "Һ"
+      ]
+    },
+    {
+      "key": "А",
+      "alternates": [
+        "Ә"
+      ]
+    },
+    {
+      "key": "О",
+      "alternates": [
+        "Ө"
+      ]
+    },
+    {
+      "key": "С",
+      "alternates": [
+        "Ҫ"
+      ]
+    },
+    {
+      "key": "Ь",
+      "alternates": [
+        "Ъ"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
The 4-row variant follows the Windows layout convention, with 'Ъ' and 'Ё' added to complete the top 11-button row